### PR TITLE
feat(error): add button to sample app

### DIFF
--- a/docs/error-handling/index.md
+++ b/docs/error-handling/index.md
@@ -4,6 +4,7 @@ title: Error Handling
 permalink: /error-handling/
 has_children: true
 nav_order: 30
+sample_branch: error-handling
 ---
 
 # Error Handling Overview


### PR DESCRIPTION
This tag added to the metadata will add a button on den overview page to the error-handling sample app in the other repository like already used in the i18n app https://1dsag.github.io/UI5-Best-Practice/i18n/