### PR TITLE
New Linting Github Action to Test Consistency and Rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,3 +15,12 @@ jobs:
           node-version: 16
     - run: npm install
     - run: npm run markdown-lint
+  GeneralLint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+          node-version: 16
+    - run: npm install
+    - run: npm run general-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: "Linting"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  MarkdownLint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+          node-version: 16
+    - run: npm install
+    - run: npm run markdown-lint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "--none",
   "scripts": {
     "create-pdf": "ts-node ./ts/to_pdf.ts",
-    "markdown-lint": "markdownlint -c .markdownlint.jsonc  ./docs"
+    "markdown-lint": "markdownlint -c .markdownlint.jsonc  ./docs",
+    "general-lint" : "ts-node ./ts/lint.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "part of the environment setup for the DSAG UI5 best practice guide",
   "main": "--none",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "create-pdf": "ts-node ./ts/to_pdf.ts",
+    "markdown-lint": "markdownlint -c .markdownlint.jsonc  ./docs"
   },
   "repository": {
     "type": "git",

--- a/ts/lint.ts
+++ b/ts/lint.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as path from "path";
+
+class Lint {
+  private _error: boolean = false;
+
+  main() {
+    this.checkFileEnding();
+    if (this._error) {
+      process.exit(1);
+    }
+  }
+
+  checkFileEnding() {
+    // loop over docs folder
+    const files = fs.readdirSync("./docs");
+    for (const file of files) {
+      // check if file ends with markdown
+      if (file.endsWith(".markdown")) {
+        console.log(`${file} has wrong file ending`);
+        this._error = true;
+      }
+    }
+  }
+}
+const lint = new Lint();
+lint.main();


### PR DESCRIPTION
## What is in this PR?
- add new github action to create several lint test
- test markdown lint with already existing custom markdown config `.markdownlint.jsonc`
- first general test is to check if all files have the same file extensions.

## Why?
This is a first basic test but can be extended to several more test