### PR TITLE
fix(error-handling): adjusted sample error handler md reference 

### DIFF
--- a/docs/error-handling/bestpractices.md
+++ b/docs/error-handling/bestpractices.md
@@ -44,7 +44,7 @@ this.getModel().read("/Entity('key')", {
 });
 ```
 
-A sample for a separate error handler file can be found in the section [Sample Error Handler](sampleerrorhandler.markdown).
+A sample for a separate error handler file can be found in the section [Sample Error Handler](sampleerrorhandler.md).
 
 ## Consider the SAP Fiori Guidelines
 
@@ -88,4 +88,4 @@ _showServiceError: function(sDetails) {
 
 This form of error output ensures that only one error is displayed and all other errors are ignored. Instead, in the case of multiple errors, you should use a [message view](https://experience.sap.com/fiori-design-web/message-view/) instead of the message box.
 
-An example for a smarter implementation can be found in the [Sample Error Handler](sampleerrorhandler.markdown).
+An example for a smarter implementation can be found in the [Sample Error Handler](sampleerrorhandler.md).


### PR DESCRIPTION
Hi again 😅,

when trying to navigate to the sample error handler, you'll get a 404. 

See link `https://1dsag.github.io/UI5-Best-Practice/error-handling/sampleerrorhandler.markdown`
![image](https://user-images.githubusercontent.com/14982812/158063845-db8ff4cc-01d3-435a-b1b7-d38cefb242c0.png)

I adjusted this accordingly.