### PR TITLE
chore: update devcontainer to bullseye (fixes RubyGames bug)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     // Update 'VARIANT' to pick a Node version: 12, 14, 16
     "args": {
-      "VARIANT": "16"
+      "VARIANT": "16-bullseye"
     }
   },
   // Set *default* container specific settings.json values on container create.
@@ -24,7 +24,7 @@
     35729
   ],
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install && sudo gem update --system 3.3.6 && sudo gem install bundler && cd docs && bundle install",
+  "postCreateCommand": "npm i -g npm@latest && hash -r && npm install && sudo gem install bundler && cd docs && bundle install",
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
 }


### PR DESCRIPTION
the initial implementation was based on debian buster & RubyGems version (2.7.6.2)

during the configuration of the container the following warning is being shown:

> Your RubyGems version (2.7.6.2) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`

the proposed fix: running `gem update --system 3.2.3`, updates all installed gems which takes its time and lead to timeouts on my machine.

this pr uses debian bullseye & RubyGems version (3.2.5)  where the bug is fixed.
in addition, it updates npm to the latest version.